### PR TITLE
Only read the master on clone

### DIFF
--- a/src/generators/app/index.ts
+++ b/src/generators/app/index.ts
@@ -30,7 +30,7 @@ class CreateGenerator extends Generator {
 
     async writing() {
         // Clone the sample apps repo
-        await git().clone(this.gitRepo, this.destPath);
+        await git().clone(this.gitRepo, this.destPath, ['-b', 'master']);
 
         // Remove the .git directory so that the user can start their git 
         // history from scratch

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -10,11 +10,22 @@ describe('CreateGenerator', () => {
 
   before(async () => {
     const tmpGitRepo = tmp.dirSync().name;
-
-    fs.writeFileSync(`${tmpGitRepo}/package.json`, '{"name: "test"}');
+    fs.writeFileSync(`${tmpGitRepo}/package.json`, '{"name": "test"}');
 
     await git(tmpGitRepo).init()
-      .catch(console.log);
+      .catch(console.error.bind(console));
+
+    await git(tmpGitRepo).addConfig('user.name', 'Some one')
+      .catch(console.error.bind(console));
+
+    await git(tmpGitRepo).addConfig('user.email', 'some@one.com')
+      .catch(console.error.bind(console));
+
+    await git(tmpGitRepo).add('./*')
+      .catch(console.error.bind(console));
+
+    await git(tmpGitRepo).commit('First commit')
+      .catch(console.error.bind(console));
 
     return helpers.run(path.join(__dirname, '../src/generators/app'))
       .withOptions({ name: appName, gitRepoUrl: tmpGitRepo });


### PR DESCRIPTION
This is because the release flow of the sample app is merging the
default branch (integration) into master. There may be lots of things
merged into the default branch that we don't yet want to release.